### PR TITLE
Make `/linkaccount` ephemeral in Discord

### DIFF
--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 const _ = require("lodash");
 const models = require("./models");
+const { MessageFlags } = require("discord.js");
 
 module.exports = (api) => {
   assert(api, "requires api");
@@ -162,9 +163,14 @@ module.exports = (api) => {
     },
     linkaccount: {
       description: "Link your account to the site.",
+      defer: false,
       handler: async (ctx) => {
         let username, totpCode;
         if (ctx.platform === "discord") {
+          await ctx.interaction.deferReply({ 
+            flags: [MessageFlags.Ephemeral] 
+          });
+
           username = ctx.getString("username");
           totpCode = ctx.getString("totp");
         } else {

--- a/src/libs/connectors/discord.js
+++ b/src/libs/connectors/discord.js
@@ -61,6 +61,7 @@ const WrapperDiscord = (context, client) => {
     getString,
     getArg,
     getContent,
+    interaction: context,
   };
 };
 
@@ -164,9 +165,12 @@ module.exports = (token, commands) =>
         if (!ctx.isCommand()) return;
         if (!_.has(commands, ctx.commandName))
           return ctx.reply("the command does not exist");
-        await ctx.deferReply();
+        const command = commands[ctx.commandName];
+        if (command.defer !== false) {
+          await ctx.deferReply();
+        }
         const wrapper = WrapperDiscord(ctx, client);
-        await Promise.resolve(commands[ctx.commandName].handler(wrapper));
+        await Promise.resolve(command.handler(wrapper));
       } catch (error) {
         if (error.code === 10062) {
           console.warn("Interaction expired:", error.message);


### PR DESCRIPTION
Currently, the DiscordWrapper defers every response before running any command handler code. This PR allows skipping this behavior by adding `defer: false` to a command. Deferring should then be handled inside that command handler, which is desired in some cases to make a message ephemeral or not depending on the command's logic.

I've used this functionality to make `/linkaccount` ephemeral so there's no chance to leak a totp code by users.
| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c0186afd-201b-4df6-b285-4c2c5f554aa0)  | ![image](https://github.com/user-attachments/assets/2161abac-82af-4921-9e81-1b84c0245ba8)<br>(Note the "Only you can see this") |