### PR TITLE
Order by the USD value of a win for `/bigwins`

### DIFF
--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -113,7 +113,7 @@ module.exports = (api) => {
           .orderBy(({ bet }) => {
             const currency = api.get("public", "currencies", bet.currency);
             if (!currency) return 0; // Skip invalid currencies
-            return bet.winnings / Math.pow(10, currency.decimals);
+            return bet.winnings / Math.pow(10, currency.decimals) * currency.price;
           })
           .reverse()
           .uniqBy("userid")


### PR DESCRIPTION
Changed the ordering function to use the amount won in USD, which makes more sense with the command response being in USD.

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c7c82053-84e3-4ea6-91dd-659aabfd3328) | ![image](https://github.com/user-attachments/assets/88e4fedb-a304-4789-aa9f-3240a441deb5) |

You can see here that `#1` from before doesn't even make the list now, and the new `#2` wasn't even on the list before despite winning that much.