### PR TITLE
Dynamically create Discord command option registrations

### DIFF
--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 const _ = require("lodash");
 const models = require("./models");
+const { ApplicationCommandOptionType } = require("discord.js");
 
 module.exports = (api) => {
   assert(api, "requires api");
@@ -21,10 +22,17 @@ module.exports = (api) => {
     prices: {
       description:
         "The different cryptocurrencies and their values in dollars. Usage: /prices [currency]",
+      options: {
+        currency: {
+          description: "Currency to filter by",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+        },
+      },
       handler: (ctx) => {
         let currency = null;
         if (ctx.platform === "discord") {
-          const currency = ctx?.getString("currency")?.toLowerCase();
+          currency = ctx?.getString("currency")?.toLowerCase();
         } else {
           currency = ctx?.getArg(1);
         }
@@ -162,11 +170,23 @@ module.exports = (api) => {
     },
     linkaccount: {
       description: "Link your account to the site.",
+      options: {
+        username: {
+          description: "Your Chips.gg username",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+        },
+        totp: {
+          description: "Your TOTP code",
+          type: ApplicationCommandOptionType.Number,
+          required: true,
+        },
+      },
       handler: async (ctx) => {
         let username, totpCode;
         if (ctx.platform === "discord") {
           username = ctx.getString("username");
-          totpCode = ctx.getString("totp");
+          totpCode = ctx.getNumber("totp");
         } else {
           username = ctx.getArg(1);
           totpCode = ctx.getArg(2);
@@ -282,9 +302,16 @@ module.exports = (api) => {
     return match ? roles[match] : null;
   }
 
-  // help menu
+  // Get user
   commands.user = {
     description: "Get user information by username",
+    options: {
+      username: {
+        description: "Chips.gg username",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    },
     handler: async (ctx) => {
       let username = null;
       if (ctx.platform === "discord") {
@@ -424,6 +451,13 @@ module.exports = (api) => {
 
   commands.search = {
     description: "Search the game catalog. Usage: /search game_name",
+    options: {
+      query: {
+        description: "Search query",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    },
     handler: async (ctx) => {
       let query = null;
       if (ctx.platform === "discord" || ctx.platform === "api") {
@@ -477,6 +511,13 @@ module.exports = (api) => {
 
   commands.stats = {
     description: "Show user stats banner. Usage: /stats username",
+    options: {
+      username: {
+        description: "Chips.gg username",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    },
     handler: async (ctx) => {
       let username = null;
       if (ctx.platform === "discord") {
@@ -519,6 +560,13 @@ module.exports = (api) => {
 
   commands.promotion = {
     description: "Show promotion banner. Usage: /promotion promotionid",
+    options: {
+      promotionid: {
+        description: "Promotion ID",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    },
     handler: async (ctx) => {
       let promotionId = null;
       if (ctx.platform === "discord") {
@@ -562,7 +610,7 @@ module.exports = (api) => {
           });
         }
       } catch (e) {
-        return ctx.sendText("Error searching promotions: " + error.message);
+        return ctx.sendText("Error searching promotions: " + e.message);
       }
     },
   };
@@ -570,6 +618,18 @@ module.exports = (api) => {
   commands.compare = {
     description:
       "Compare two users' stats. Usage: /compare username1 username2",
+    options: {
+      username1: {
+        description: "First Chips.gg username",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+      username2: {
+        description: "Second Chips.gg username",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    },
     handler: async (ctx) => {
       let username1, username2;
       if (ctx.platform === "discord") {
@@ -613,6 +673,13 @@ module.exports = (api) => {
 
   commands.bet = {
     description: "Show bet card. Usage: /bet betid",
+    options: {
+      betid: {
+        description: "Bet ID",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    },
     handler: async (ctx) => {
       let betId = null;
       if (ctx.platform === "discord") {

--- a/src/libs/connectors/discord.js
+++ b/src/libs/connectors/discord.js
@@ -86,59 +86,16 @@ module.exports = (token, commands) =>
           const command = commands[name];
           const options = [];
 
-          if (name === "user" || name === "stats") {
-            options.push({
-              name: "username",
-              description: "Username to look up",
-              type: 3,
-              required: true,
-            });
-          } else if (name === "promotion") {
-            options.push({
-              name: "promotionid",
-              description: "Promotion ID to look up",
-              type: 3,
-              required: true,
-            });
-          } else if (name === "bet") {
-            options.push({
-              name: "betid",
-              description: "Bet ID to look up",
-              type: 3,
-              required: true,
-            });
-          } else if (name === "auth" || name === "linkaccount") {
-            options.push(
-              {
-                name: "username",
-                description: "Your Chips.gg username",
-                type: 3,
-                required: true,
-              },
-              {
-                name: "totp",
-                description: "Your TOTP authentication code",
-                type: 3,
-                required: true,
-              },
-            );
-          } else if (name === "compare") {
-            options.push(
-              {
-                name: "username1",
-                description: "First username to compare",
-                type: 3,
-                required: true,
-              },
-              {
-                name: "username2",
-                description: "Second username to compare",
-                type: 3,
-                required: true,
-              }
-            );
+          for (const [name, settings] of Object.entries(command.options ?? {})) {
+            const option = {
+              name,
+              description: settings.description,
+              type: settings.type,
+              required: settings.required,
+            };
+            
+            options.push(option);
           }
-
 
           return {
             name,

--- a/src/libs/connectors/discord.js
+++ b/src/libs/connectors/discord.js
@@ -51,6 +51,7 @@ const WrapperDiscord = (context, client) => {
   const getContent = () => context.message?.content || "";
   const getArg = (index) => getContent().split(" ")[index];
   const getString = (param) => context.options?.getString(param);
+  const getNumber = (param) => context.options?.getNumber(param);
 
   return {
     platform: "discord",
@@ -59,6 +60,7 @@ const WrapperDiscord = (context, client) => {
     sendForm,
     sendText,
     getString,
+    getNumber,
     getArg,
     getContent,
   };

--- a/src/libs/connectors/telegram.js
+++ b/src/libs/connectors/telegram.js
@@ -53,8 +53,12 @@ const WrapperTelegram = (context) => {
       return x.contains(string).split(":")[1];
     });
 
-    return cmd ? cmd : text.split(" ")[1];
+    return cmd ? cmd : context.message.text.split(" ")[1];
   };
+
+  const getNumber = (string) => {
+    return parseInt(getString(string));
+  }
 
   return {
     platform: "telegram",
@@ -63,6 +67,7 @@ const WrapperTelegram = (context) => {
     sendText,
     getArg,
     getString,
+    getNumber,
   };
 };
 


### PR DESCRIPTION
This PR removes the hard coded registration to add slash command options with a big if-else chain, and instead moves the options to the commands. This allows for more command options to be added where you're working, so everything is in one place rather than jumping around to make sure the options are registered.

![image](https://github.com/user-attachments/assets/650cc7c4-d344-4b69-904c-960b1d9c533e)

This is kept as simple as possible right now, with just the option name (as the object key), description, type, and required flag being available. I imagine that adding autocomplete support as well as min/max values and options may come in the future.