### PR TITLE
Add command loader to scan files in commands folder

### DIFF
--- a/src/commands/promotions.js
+++ b/src/commands/promotions.js
@@ -1,0 +1,10 @@
+const models = require("../libs/models");
+
+module.exports = (api) => ({
+  name: "promotions",
+  description: "Ongoing promotions and events",
+  handler: async (ctx) => {
+    const activeRaces = await api._actions.public("listRunningPromotions");
+    return ctx.sendForm(models.events(activeRaces));
+  },
+});

--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -60,13 +60,6 @@ module.exports = (api) => {
         return ctx.sendForm(models.prices(currencies.value()));
       },
     },
-    promotions: {
-      description: "Ongoing promotions and events",
-      handler: async (ctx) => {
-        const activeRaces = await api._actions.public("listRunningPromotions");
-        return ctx.sendForm(models.events(activeRaces));
-      },
-    },
     vault: {
       description: "The vault and rewards related",
       handler: (ctx) => {

--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -661,5 +661,33 @@ module.exports = (api) => {
     handler: (ctx) => ctx.sendForm(models.help(commands)),
   };
 
+  const loadedCommands = loadCommands(api);
+  Object.assign(commands, loadedCommands);
+
+  console.log(`Loaded ${Object.keys(commands).length} commands!`);
+
   return commands;
 };
+
+function loadCommands(api) {
+  const fs = require("fs");
+  const path = require("path");
+
+  const commands = {};
+  const dir = path.join(__dirname, "../commands");
+  const files = fs.readdirSync(dir);
+
+  for (const file of files) {
+    if (!file.endsWith(".js")) continue;
+
+    try {
+      const module = require(path.join(dir, file));
+      const command = module(api);
+      commands[command.name || file.replace(".js", "").trim()] = command;
+    } catch (error) {
+      console.error("Error loading command:", file, error);
+    }
+  }
+
+  return commands;
+}


### PR DESCRIPTION
This PR adds the ability to make dedicated files for each command. I only moved `/promotions` to this new system for now. Other commands can be moved as they're updated.

Adding a new command is now as simple as making a new file under `/src/commands` and adding an export like this:
```js
// src/commands/promotions.js
const models = require("../libs/models");

module.exports = (api) => ({
  name: "promotions",
  description: "Ongoing promotions and events",
  handler: async (ctx) => {
    const activeRaces = await api._actions.public("listRunningPromotions");
    return ctx.sendForm(models.events(activeRaces));
  },
});
```
The only new property here is `name`, but I've also made that optional by using the file name as a fallback.