### PR TITLE
Fix `/koth` image in Discord

### DIFF
--- a/src/commands/koth.js
+++ b/src/commands/koth.js
@@ -1,15 +1,32 @@
+const { AttachmentBuilder } = require("discord.js");
+
 module.exports = () => ({
   name: "koth",
   description: "Display current King of the Hill information",
   handler: async (ctx) => {
     // const koth = api.get('public', 'koth');
 
+    if (ctx.platform !== "discord") {
+      return ctx.sendForm({
+        emoji: "👑",
+        title: "KING OF THE HILL",
+        banner: "https://stats.chips.gg/koth",
+        buttonLabel: "BE KING.",
+        url: "https://chips.gg/koth",
+      });
+    }
+
     return ctx.sendForm({
       emoji: "👑",
       title: "KING OF THE HILL",
-      banner: `https://stats.chips.gg/koth`,
+      banner: `attachment://koth.png`,
       buttonLabel: "BE KING.",
       url: "https://chips.gg/koth",
+      files: [
+        new AttachmentBuilder("https://stats.chips.gg/koth", {
+          name: "koth.png",
+        }),
+      ],
     });
   },
 });

--- a/src/libs/connectors/discord.js
+++ b/src/libs/connectors/discord.js
@@ -8,7 +8,8 @@ const {
   ButtonStyle,
 } = require("discord.js");
 const discordMakeForm = (options) => {
-  const { emoji, title, content, footer, banner, url, buttonLabel } = options;
+  const { emoji, title, content, footer, banner, url, buttonLabel, files } =
+    options;
   const row = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setStyle(ButtonStyle.Link)
@@ -37,6 +38,7 @@ const discordMakeForm = (options) => {
     embeds: [embed],
     components: url && buttonLabel ? [row] : [],
     ephemeral: options.ephemeral || false,
+    files: files || [],
   };
 };
 


### PR DESCRIPTION
This PR allows `files` to be added to ctx.sendForm(...), which enables ImageAttachments for Discord to be used. Using an image attachment fixes the KOTH image not sending in Discord.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/3f6e8c1b-49d5-46f9-88e3-a819a3c5c48d) | ![image](https://github.com/user-attachments/assets/0e8d9a5e-4dfe-4d46-b149-b485e1f36d92) |