### PR TITLE
Add hyperlinks to `/mostplayed`

### DIFF
--- a/src/commands/mostplayed.js
+++ b/src/commands/mostplayed.js
@@ -8,14 +8,25 @@ module.exports = (api) => ({
       duration: "1m",
     });
 
+    const content =
+      ctx.platform === "discord" || ctx.platform === "telegram"
+        ? games.map(hyperlinkMap).join("\n")
+        : games.map(defaultMap).join("\n");
+
     return ctx.sendForm({
       emoji: "🎮",
       title: "Most Played Games",
-      content: games
-        .map((game, index) => `${index + 1}. ${game.title} (${game.provider})`)
-        .join("\n"),
+      content: content,
       url: "https://chips.gg/casino",
       buttonLabel: "Play Now",
     });
   },
 });
+
+function hyperlinkMap(game, index) {
+  return `${index + 1}. **[${game.title}](https://chips.gg/play/${game.slug})** by [${game.provider}](https://chips.gg/casino/providers/${game.provider})`;
+}
+
+function defaultMap(game, index) {
+  return `${index + 1}. ${game.title} (${game.provider})`;
+}


### PR DESCRIPTION
This PR changes the formatting for `/mostplayed` to give it hyperlinks in both Discord and Telegram to easily play a specific game or open the page of a provider.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c969f6fd-fbd5-471f-be76-a15711efa2a8) | ![image](https://github.com/user-attachments/assets/987bf07b-382d-45b9-8620-d04542b565c6) |
| ![image](https://github.com/user-attachments/assets/39764457-ef9e-48fc-beff-bbd268e6a5b9) | <img src=https://github.com/user-attachments/assets/a687c8b5-1648-400c-9a31-2039eacf6595 width=300><br>(This also embeds the first link in chat, I'm not sure how to remove that) |