### PR TITLE
Rework `/slotcall` command for Discord

### DIFF
--- a/src/commands/slotcall.js
+++ b/src/commands/slotcall.js
@@ -1,15 +1,84 @@
 const models = require("../libs/models");
+const {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require("discord.js");
 
 module.exports = (api) => ({
   name: "slotcall",
   description: "Get a random slot",
   handler: async (ctx) => {
-    const slot = await api.getRandomSlot();
+    let slot = await api.getRandomSlot();
 
-    return ctx.sendForm(
-      models.slotcall({
-        ...slot,
-      })
-    );
+    if (ctx.platform !== "discord") {
+      return ctx.sendForm(
+        models.slotcall({
+          ...slot,
+        })
+      );
+    }
+
+    const message = await ctx.interaction.editReply(randomSlotReply(slot));
+
+    const collector = message.createMessageComponentCollector({
+      time: 60000,
+    });
+
+    collector.on("collect", async (interaction) => {
+      if (interaction.user.id !== ctx.interaction.user.id) {
+        return interaction.reply({
+          content: "Run the command yourself to use this button!",
+          ephemeral: true,
+        });
+      }
+
+      if (interaction.customId === "slotcall") {
+        collector.resetTimer();
+
+        slot = await api.getRandomSlot();
+        await interaction.update(randomSlotReply(slot));
+      }
+    });
+
+    collector.on("end", async () => {
+      const newRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setStyle(ButtonStyle.Link)
+          .setLabel("Play now!")
+          .setURL(`https://chips.gg/play/${slot.slug}`)
+      );
+      await message.edit({ components: [newRow] });
+    });
   },
 });
+
+function randomSlotReply(slot) {
+  const embed = new EmbedBuilder()
+    .setAuthor({
+      name: slot.title,
+      url: `https://chips.gg/play/${slot.slug}`,
+    })
+    .setDescription(
+      `:tophat: ${slot.producer}\n:moneybag: RTP **${slot.rtp}%**\n-# :label: ${slot.tags.join(", ")}`
+    );
+  if (slot.images.s1) {
+    embed.setThumbnail(slot.images.s1);
+  } else if (slot.images.bg) {
+    embed.setThumbnail(slot.images.bg);
+  }
+
+  const linkBtn = new ButtonBuilder()
+    .setStyle(ButtonStyle.Link)
+    .setLabel("Play now!")
+    .setURL(`https://chips.gg/play/${slot.slug}`);
+  const rerollBtn = new ButtonBuilder()
+    .setStyle(ButtonStyle.Primary)
+    .setLabel("Reroll")
+    .setCustomId("slotcall");
+
+  const row = new ActionRowBuilder().addComponents(linkBtn, rerollBtn);
+
+  return { embeds: [embed], components: [row] };
+}

--- a/src/libs/models/slotcall/scheme.js
+++ b/src/libs/models/slotcall/scheme.js
@@ -9,6 +9,6 @@ module.exports = ({ id, title, producer, rtp, images }) => ({
 🎩 RTP ${Humanize.formatNumber(rtp, 2)}%`,
   footer: "Good Luck and may the Chips be forever stacked in your favour ⭐️",
   banner: images.s2,
-  url: `https://chips.gg/casino/${id}`,
+  url: `https://chips.gg/play/${id}`,
   buttonLabel: "🎰 PLAY NOW 🎰",
 });


### PR DESCRIPTION
This PR reworks the `/slotcall` command for Discord. I moved the image to be the thumbnail image to save space in chat, and added a `Reroll` button that gets a new random slot and updates the message with it.

I also changed the play now links to `/play/{id}` since the old `/casino/{id}` route doesn't seem to work anymore.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/8915e460-3468-4012-9f86-a31b351fca1f) | ![image](https://github.com/user-attachments/assets/c9095520-d2ee-41d6-a743-accfe470a077) |